### PR TITLE
Proper boostrap specific error message styling on forms

### DIFF
--- a/templates/Includes/Form.ss
+++ b/templates/Includes/Form.ss
@@ -2,11 +2,11 @@
 <form class="form form-horizonal" $AttributesHTML>
 <% end_if %>
 	<% if Message %>
-	<div id="{$FormName}_error" class="alert alert-error message $MessageType">
+	<div id="{$FormName}_error" class="alert message $MessageType <% if $MessageType == 'good' %>alert-success<% else_if $MessageType == 'bad' %>alert-danger<% else_if $MessageType == 'warning' %>alert-warning<% end_if %>">
 		$Message
 	</div>
 	<% else %>
-	<div id="{$FormName}_error" class="alert alert-error message $MessageType" style="display: none"></div>
+	<div id="{$FormName}_error" class="alert message $MessageType" style="display: none"></div>
 	<% end_if %>
 
 	<fieldset>


### PR DESCRIPTION
This is not super clean but it allows you to easily use the following in your forms:

```
$this->sessionMessage("my message", 'bad'); //could be good, bad, or warning
```

See http://api.silverstripe.org/3.1/source-class-Form.html#1052-1067

I also removed the `alert-error` style - don't see any need for it -maybe it's a leftover from Bootstrap 2.
